### PR TITLE
Escape single quotes in path names when setting _z_marks.

### DIFF
--- a/z.fish
+++ b/z.fish
@@ -208,7 +208,9 @@ function z -d "Jump to a recent directory."
 end
 
 function _z_update_completions
-    set -x _z_marks (cat $HOME/.z | sed "s/|.*//" | tr '\n' ' ')
+    set -x _z_marks (
+        cat $HOME/.z | sed "s/|.*//" | sed "s/'/\\\'/" | tr '\n' ' '
+        )
     complete -c z -a $_z_marks -f
 end
 _z_update_completions


### PR DESCRIPTION
Had `z.fish` mess up my command prompt after visiting some oddly named folders in my music directory.
This will fix issues with path names like "John's path".

Your fork of Steve's original port seems the most up-to-date, so I opened a PR.
